### PR TITLE
(maybe a) fix for patron page broken links

### DIFF
--- a/nuxt/pages/patrons/index.vue
+++ b/nuxt/pages/patrons/index.vue
@@ -8,7 +8,7 @@
                 <v-flex class="xs3" v-for="(patron, index) in patrons" :key="index" >
                     <v-card>
                         <v-card-media :src="patron.picture" :height="imageHeight">
-                            <nuxt-link to="/" style="width: 100%; height: 100%" :title="$t('visitPatronProfile')"></nuxt-link>
+                            <nuxt-link :to="'/users/'+patron.username" style="width: 100%; height: 100%" :title="$t('visitPatronProfile')"></nuxt-link>
                         </v-card-media>
                         <v-card-text>
                             <p class="mb-0 mt-0 thetitle">

--- a/nuxt/pages/patrons/index.vue
+++ b/nuxt/pages/patrons/index.vue
@@ -8,7 +8,7 @@
                 <v-flex class="xs3" v-for="(patron, index) in patrons" :key="index" >
                     <v-card>
                         <v-card-media :src="patron.picture" :height="imageHeight">
-                            <nuxt-link :to="'/users/'+patron.username" style="width: 100%; height: 100%" :title="$t('visitPatronProfile')"></nuxt-link>
+                            <nuxt-link :to="$fs.userPath(patron.username)" style="width: 100%; height: 100%" :title="$t('visitPatronProfile')"></nuxt-link>
                         </v-card-media>
                         <v-card-text>
                             <p class="mb-0 mt-0 thetitle">


### PR DESCRIPTION
The links to the user profiles in the patron page are broken. I don't know anything about Nuxt and I don't know if this would fix it (do the ':' before the attributes mean that you can use variables? I'm just guessing here), but you get the idea ;)