### PR TITLE
Typos in docs/contribute and docs/core/fundamentals

### DIFF
--- a/nuxt/content/en/docs/contribute.md
+++ b/nuxt/content/en/docs/contribute.md
@@ -57,7 +57,7 @@ We'd love to get pictures to [showcase](/showcase) on the site too.
 
 **Contribute to our code**
 
-Interesting in submitting a pull request for our code? Awesome. All our code is [on GitHub](https://github.com/freesewing). 
+Interested in submitting a pull request for our code? Awesome. All our code is [on GitHub](https://github.com/freesewing). 
 
 Our [chat room on Gitter](https://gitter.im/freesewing/freesewing) is the best place to discuss ideas or ask questions. 
 

--- a/nuxt/content/en/docs/core/fundamentals.md
+++ b/nuxt/content/en/docs/core/fundamentals.md
@@ -138,4 +138,4 @@ return the standard SVG, but turns that automatically in a PDF.
 ### Channels
 
 Channels currently handle unit conversions and access control.
-The will be removed in future versions of core, and you can largely ignore them.
+They will be removed in future versions of core, and you can largely ignore them.


### PR DESCRIPTION
See diff for details.
